### PR TITLE
Make the jobs unique and on their own queue just for recommendations

### DIFF
--- a/lib/recommendable/workers/sidekiq.rb
+++ b/lib/recommendable/workers/sidekiq.rb
@@ -3,7 +3,7 @@ module Recommendable
     class Sidekiq
       if defined?(::Sidekiq)
         include ::Sidekiq::Worker
-        sidekiq_options queue: :low
+        sidekiq_options :unique => true, :queue => :recommendable
       end
 
       def perform(user_id)


### PR DESCRIPTION
Uses `sidekiq-middleware` in our main project to allow this.

See https://github.com/davidcelis/recommendable/blob/master/lib/recommendable/workers/sidekiq.rb for this.

We also now want to queue recommendation jobs on their own `recommendable` queue in Sidekiq.
